### PR TITLE
Display number of likes for each item on the Homepage

### DIFF
--- a/src/modules/display-home.js
+++ b/src/modules/display-home.js
@@ -1,6 +1,6 @@
 import getShow from './get-show.js';
 import addLike from './add-like.js';
-import getLikes from './get-likes.js';
+import displayLikes from './display-likes.js'
 
 const displayItems = document.getElementById('displayItems');
 const baseURL = 'https://api.tvmaze.com/lookup/shows?imdb=';
@@ -33,7 +33,7 @@ const displayHome = (item) => {
   likesCouter.classList.add('counter');
   likesCouter.id = item;
   showLikes.appendChild(likesCouter);
-  getLikes();
+  displayLikes();
 
   const btnComments = document.createElement('button');
   btnComments.innerHTML = 'Comments';
@@ -48,7 +48,7 @@ const displayHome = (item) => {
 
   likesIcon.addEventListener('click', async () => {
     await addLike(item);
-    await getLikes();
+    await displayLikes();
   });
 };
 

--- a/src/modules/display-home.js
+++ b/src/modules/display-home.js
@@ -1,6 +1,6 @@
 import getShow from './get-show.js';
 import addLike from './add-like.js';
-import displayLikes from './display-likes.js'
+import displayLikes from './display-likes.js';
 
 const displayItems = document.getElementById('displayItems');
 const baseURL = 'https://api.tvmaze.com/lookup/shows?imdb=';

--- a/src/modules/display-likes.js
+++ b/src/modules/display-likes.js
@@ -9,7 +9,7 @@ const updateCounter = (element) => {
   }
 };
 
-const getLikes = async () => {
+const displayLikes = async () => {
   fetch(appURL)
     .then(async (response) => {
       const data = await response.json();
@@ -20,4 +20,4 @@ const getLikes = async () => {
     });
 };
 
-export default getLikes;
+export default displayLikes;


### PR DESCRIPTION
When the page loads, the webapp fetches the [Involvement API](https://www.notion.so/microverse/Involvement-API-869e60b5ad104603aa6db59e08150270) to show the item likes and combines them with the data from the base API.

Remember that your page should make only 2 requests:
- one to the base API
- and **one** to the Involvement API.